### PR TITLE
Schema updates for device_capability_model_uri and model_repository_uri 

### DIFF
--- a/pnpbridge/src/pnpbridge/src/pnpbridge_config_schema.json
+++ b/pnpbridge/src/pnpbridge/src/pnpbridge_config_schema.json
@@ -75,7 +75,7 @@
 						"type": "string"
 					}
 				  },
-				  "required": ["connection_string"]
+				  "required": ["connection_string", "device_capability_model_uri"]
 				},
 				{
 				  "properties": {
@@ -84,7 +84,7 @@
 						"$ref": "#/definitions/dps_parameters_schema"
 					}
 				  },
-				  "required": ["dps_parameters"]
+				  "required": ["dps_parameters", "device_capability_model_uri"]
 				},
 				{
 					"properties": {
@@ -131,8 +131,7 @@
 			"required": [
 				"global_prov_uri",
 				"id_scope",
-				"device_id",
-				"model_repository_uri"
+				"device_id"
 			]
 		},
 		"device_schema" : {


### PR DESCRIPTION
1. device_capability_model_uri is required for both connection_string and DPS based connections
2. model_repository_uri is no longer required for DPS parameters